### PR TITLE
Fixes #4 - NPM registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const config = {
   // see if it needs to build the package version or not
   skipPackagesAtUrl: 'https://cdn.example.com/npm/',
 
-  // Optional, defaults to the output of "npm get registry".
+  // Optional, defaults to the public npm registry.
   // When provided, this allows you to specify the npm registry 
   // which is then used to fetch all packages.
   npmRegistry: 'https://registry.npmjs.org/',

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ const config = {
   // see if it needs to build the package version or not
   skipPackagesAtUrl: 'https://cdn.example.com/npm/',
 
+  // Optional, defaults to the output of "npm get registry".
+  // When provided, this allows you to specify the npm registry 
+  // which is then used to fetch all packages.
+  npmRegistry: 'https://registry.npmjs.org/',
+
   // Optional, defaults to "debug". Must be one of "debug", "warn", or "fatal"
   // This changes the verbosity of the stdout logging
   logLevel: "warn",

--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -11,7 +11,6 @@ import http from "http";
 import micromatch from "micromatch";
 import url from "url";
 import ejs from "ejs";
-import * as child from "child_process";
 
 const rimraf = util.promisify(_rimraf);
 const renderFile = util.promisify(ejs.renderFile);
@@ -372,21 +371,12 @@ export async function build({
   }
 
   function getNpmFetchOptions() {
-    let localRegistry
     if (npmRegistry) {
-      localRegistry = npmRegistry
-    } else {
-      try {
-        localRegistry = child.execSync("npm get registry",
-            {stdio: ["ignore", "pipe", "pipe"]}).toString().replace(/\n$/, "");
-      } catch (e) {
-        debug("Could not execute 'npm get registry'.")
-        return undefined
+      return {
+        registry: npmRegistry
       }
     }
-    return {
-      registry: localRegistry
-    }
+    return undefined
   }
 
   function log(priority, msg) {

--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -11,6 +11,7 @@ import http from "http";
 import micromatch from "micromatch";
 import url from "url";
 import ejs from "ejs";
+import * as child from "child_process";
 
 const rimraf = util.promisify(_rimraf);
 const renderFile = util.promisify(ejs.renderFile);
@@ -58,6 +59,7 @@ export async function build({
   absoluteDir,
   skipPackagesAtUrl,
   generateDockerfile,
+  npmRegistry,
 }) {
   const start = Date.now();
 
@@ -99,6 +101,10 @@ export async function build({
 
   if (skipPackagesAtUrl && typeof skipPackagesAtUrl !== "string") {
     throw Error(`${errPrefix} skipPackagesAtUrl must be a string`);
+  }
+
+  if (npmRegistry && typeof npmRegistry !== "string") {
+    throw Error(`${errPrefix} npmRegistry must be a string`);
   }
 
   packages.forEach((p, i) => {
@@ -180,6 +186,8 @@ export async function build({
     }
   });
 
+  const npmFetchOptions = getNpmFetchOptions()
+
   if (clean) {
     await rimraf(outputDir);
   }
@@ -220,7 +228,7 @@ export async function build({
     yield [logLevels.warn, `--> ${p.name}`];
 
     try {
-      metadata = await npmFetch.json(`/${p.name}`);
+      metadata = await npmFetch.json(`/${p.name}`, npmFetchOptions);
     } catch (err) {
       yield [logLevels.warn, err];
       return yield [
@@ -325,7 +333,10 @@ export async function build({
         });
 
         const tarballUrl = metadata.versions[matchedVersion].dist.tarball;
-        const requestStream = https.request(tarballUrl);
+        const requestStream = (tarballUrl.startsWith("http://")
+          ? http
+          : https
+        ).request(tarballUrl);
 
         requestStream.on("response", (responseStream) => {
           responseStream.pipe(untarStream);
@@ -357,6 +368,24 @@ export async function build({
       for (let file of files) {
         yield [logLevels.debug, `------> ${file}`];
       }
+    }
+  }
+
+  function getNpmFetchOptions() {
+    let localRegistry
+    if (npmRegistry) {
+      localRegistry = npmRegistry
+    } else {
+      try {
+        localRegistry = child.execSync("npm get registry",
+            {stdio: ["ignore", "pipe", "pipe"]}).toString().replace(/\n$/, "");
+      } catch (e) {
+        debug("Could not execute 'npm get registry'.")
+        return undefined
+      }
+    }
+    return {
+      registry: localRegistry
     }
   }
 


### PR DESCRIPTION
Configured npm registry is now always used by default. You can override that by using the configuration `npmRegistry`.