### PR TITLE
Fixes  #6 - Packages with a slash

### DIFF
--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -288,7 +288,7 @@ export async function build({
       try {
         await fs.stat(dir);
       } catch {
-        await fs.mkdir(dir);
+        await fs.mkdir(dir, { recursive: true });
       }
 
       const include = matchedVersion.include || p.include || [];


### PR DESCRIPTION
Now packages with a slash like `@company/my-lib` are unpacked correctly.