### PR TITLE
Support registryFetchOptions config. Resolves #11.

### DIFF
--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -60,6 +60,7 @@ export async function build({
   skipPackagesAtUrl,
   generateDockerfile,
   npmRegistry,
+  registryFetchOptions,
 }) {
   const start = Date.now();
   const packages = !usePackageJSON
@@ -189,7 +190,7 @@ export async function build({
     }
   });
 
-  const npmFetchOptions = getNpmFetchOptions()
+  const npmFetchOptions = getNpmFetchOptions();
 
   if (clean) {
     await rimraf(outputDir);
@@ -375,12 +376,17 @@ export async function build({
   }
 
   function getNpmFetchOptions() {
-    if (npmRegistry) {
-      return {
-        registry: npmRegistry
-      }
+    const options = {};
+
+    if (registryFetchOptions) {
+      Object.assign(options, registryFetchOptions);
     }
-    return undefined
+
+    if (npmRegistry) {
+      Object.assign(options, npmRegistry);
+    }
+
+    return options;
   }
 
   function log(priority, msg) {

--- a/test/happy-path/conf.js
+++ b/test/happy-path/conf.js
@@ -5,7 +5,11 @@ export default {
   clean: true,
   // skipPackagesAtUrl: 'https://unpkg.com/',
   generateDockerfile: true,
-  logLevel: "warn",
+  logLevel: "debug",
+  registryFetchOptions: {
+    username: "fake-username",
+    password: "not-the-real-password",
+  },
   packages: [
     {
       name: "react",


### PR DESCRIPTION
See #11. The options are passed through as the `opts` described in https://github.com/npm/npm-registry-fetch#-fetch-options