### PR TITLE
Add missing typedefs

### DIFF
--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -383,7 +383,7 @@ export async function build({
     }
 
     if (npmRegistry) {
-      Object.assign(options, npmRegistry);
+      Object.assign(options, { registry: npmRegistry });
     }
 
     return options;

--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -388,7 +388,7 @@ export async function build({
     }
 
     if (npmRegistry) {
-      Object.assign(options, { registry: npmRegistry });
+      Object.assign(options, npmRegistry);
     }
 
     return options;

--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -49,7 +49,6 @@ const logLevels = {
  *  skipPackagesAtUrl?: string,
  *  generateDockerfile?: boolean,
  *  usePackageJSON?: boolean,
- *  npmRegistry?: string,
  *  registryFetchOptions?: RegistryFetchOptions,
  * }} BuildOpts
  *

--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -38,6 +38,8 @@ const logLevels = {
  *  exclude?: string[],
  * }} PackageToBuild
  *
+ * @typedef { import("npm-registry-fetch").Options } RegistryFetchOptions
+ *
  * @typedef {{
  *  packages: PackageToBuild[],
  *  outputDir?: string,
@@ -46,6 +48,9 @@ const logLevels = {
  *  absoluteDir?: boolean,
  *  skipPackagesAtUrl?: string,
  *  generateDockerfile?: boolean,
+ *  usePackageJSON?: boolean,
+ *  npmRegistry?: string,
+ *  registryFetchOptions?: RegistryFetchOptions,
  * }} BuildOpts
  *
  * @param {BuildOpts} opts


### PR DESCRIPTION
Hey @joeldenning,

When I was implementing #14 I noticed that some typedefs were missing, so I tried to resolve them. In particular I'm unsure about `registryFetchOptions` as it's defined in `npm-registry-fetch`.

It produces something kind of strange for the typedefs
```typescript
/* ... */
export type RegistryFetchOptions = import("npm-registry-fetch").Options;
export type BuildOpts = {
  /* ... */
  registryFetchOptions?: RegistryFetchOptions;
};
```

That being said, it gives my editor appropriate hinting for autocomplete, so maybe it's okay. Let me know what you think.