### PR TITLE
Remove npmRegistry option. Document registryFetchOptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,6 @@ const config = {
   // see if it needs to build the package version or not
   skipPackagesAtUrl: "https://cdn.example.com/npm/",
 
-  // Optional, defaults to the public npm registry.
-  // When provided, this allows you to specify the npm registry
-  // which is then used to fetch all packages.
-  npmRegistry: "https://registry.npmjs.org/",
-
   // Optional, defaults to {}.
   // When provided, this allows you to configure the behavior of npm-registry-fetch,
   // such as providing username, password, or token to access private npm packages.
@@ -173,11 +168,15 @@ const config = {
     username: "test",
     password: "test",
     token: "test",
+    registry: "https://registry.npmjs.org/",
   },
 
   // Optional, defaults to "debug". Must be one of "debug", "warn", or "fatal"
   // This changes the verbosity of the stdout logging
   logLevel: "warn",
+
+  // Optional, defaults to true. This is a safeguard against the clean operation deleting important directories accidentally, by forcing them to be absolute paths. To disable that behavior, set to false.
+  absoluteDir: true,
 };
 
 export default config;

--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -59,7 +59,6 @@ export async function build({
   absoluteDir,
   skipPackagesAtUrl,
   generateDockerfile,
-  npmRegistry,
   registryFetchOptions,
 }) {
   const start = Date.now();
@@ -105,10 +104,6 @@ export async function build({
 
   if (skipPackagesAtUrl && typeof skipPackagesAtUrl !== "string") {
     throw Error(`${errPrefix} skipPackagesAtUrl must be a string`);
-  }
-
-  if (npmRegistry && typeof npmRegistry !== "string") {
-    throw Error(`${errPrefix} npmRegistry must be a string`);
   }
 
   packages.forEach((p, i) => {
@@ -380,10 +375,6 @@ export async function build({
 
     if (registryFetchOptions) {
       Object.assign(options, registryFetchOptions);
-    }
-
-    if (npmRegistry) {
-      Object.assign(options, npmRegistry);
     }
 
     return options;


### PR DESCRIPTION
Resolves #13. This is a breaking change because it removes an option that was previously supported. Those migrating should use `registryFetchOptions.registry` rather than `npmRegistry` in their configuration.