### PR TITLE
multiple fixes

### DIFF
--- a/lib/self-hosted-shared-dependencies.js
+++ b/lib/self-hosted-shared-dependencies.js
@@ -231,7 +231,11 @@ export async function build({
     yield [logLevels.warn, `--> ${p.name}`];
 
     try {
-      metadata = await npmFetch.json(`/${p.name}`, npmFetchOptions);
+      metadata = await npmFetch.json(`/${p.name}`, {
+        ...npmFetchOptions,
+        // pass in spec so that npmFetch tries to resolve scoped registries
+        spec: p.name,
+      });
     } catch (err) {
       yield [logLevels.warn, err];
       return yield [
@@ -241,7 +245,9 @@ export async function build({
     }
 
     const matchedVersions = Object.keys(metadata.versions).filter((version) =>
-      p.versions.some((v) => semver.satisfies(version, v))
+      p.versions
+        .map((v) => (typeof v === "string" ? v : v.version))
+        .some((v) => semver.satisfies(version, v))
     );
 
     if (matchedVersions.length > 0) {
@@ -309,7 +315,7 @@ export async function build({
       await new Promise((resolve, reject) => {
         const untarStream = tar.extract({
           cwd: dir,
-          filter(path, entry) {
+          filter(path) {
             const filePath = path.slice("package/".length);
 
             if (isLicense(filePath) || isPackageJson(filePath)) {
@@ -335,27 +341,10 @@ export async function build({
         });
 
         const tarballUrl = metadata.versions[matchedVersion].dist.tarball;
-        const requestStream = (
-          tarballUrl.startsWith("http://") ? http : https
-        ).request(tarballUrl);
 
-        requestStream.on("response", (responseStream) => {
-          responseStream.pipe(untarStream);
-        });
-
-        requestStream.on("timeout", () => {
-          reject(
-            Error(
-              `Request timed out to download tarball for ${p.name}@${matchedVersion}`
-            )
-          );
-        });
-
-        requestStream.on("error", (err) => {
-          reject(err);
-        });
-
-        requestStream.end();
+        npmFetch(tarballUrl, npmFetchOptions)
+          .then((res) => res.body.pipe(untarStream))
+          .catch(reject);
 
         untarStream.on("end", () => {
           resolve();


### PR DESCRIPTION
## Motivation

While experimenting with `self-hosted-shared-dependencies`, I faced 3 issues:
1. #19
2. scoped packages are not being resolved to the respective scoped registry 
  2.1. example: `@privatescope:registry = "https://privatescope-registry.com"`
3. PackageVersions structured as objects `{version: string, include?: string[], exclude?: string[]}` are ignored

## Changes

- extend support for private registries
  - provide spec property to `npmFetch` for it to resolve registries associated to a scope
  - use `npmFetch` to get tarball
- fix support for PackageVersions structured as objects